### PR TITLE
update image reference in parladata deployment

### DIFF
--- a/kustomize/deployment.yaml
+++ b/kustomize/deployment.yaml
@@ -39,7 +39,7 @@ spec:
                 name: parladata-credentials
       containers:
         - name: parladata
-          image: rg.fr-par.scw.cloud/djnd/parladata:latest
+          image: parladata
           command:
             - gunicorn
             - parladata_project.wsgi:application


### PR DESCRIPTION
so it loads the correct hash-tagged image instead of "latest"